### PR TITLE
PyPSA can do unit-representation of technology options

### DIFF
--- a/tools/pypsa/features.yaml
+++ b/tools/pypsa/features.yaml
@@ -62,8 +62,9 @@ features:
       source: []
       value: n
     units:
-      source: []
-      value: n
+      source:
+        - https://docs.pypsa.org/latest/user-guide/optimization/capacity-limits/#modularity-constraints
+      value: y
   asset__chaining:
     asset_linking:
       value: y


### PR DESCRIPTION
Closes #

## Summary of changes in this pull request

- added link to modular representation of technology options

## Contributor checklist

- [ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license / CC-BY-4.0 license (if a feature list).
- [X] I have added myself to the list of contributors in `AUTHORS.md` if editing files outside feature lists of which I am a maintainer.