### PR TITLE
fix OSeMOSYS: asset_outages

### DIFF
--- a/tools/OSeMOSYS/features.yaml
+++ b/tools/OSeMOSYS/features.yaml
@@ -296,8 +296,9 @@ features:
       value: dev
   robustness:
     asset_outages:
-      source: []
-      value: n
+      source:
+        - https://osemosys.readthedocs.io/en/latest/manual/Debugging%20a%20model.html#capacity-factors
+      value: y
     eens_limit:
       source: []
       value: n


### PR DESCRIPTION
Is done via capacity factor upper limits

Closes #

## Summary of changes in this pull request

- An upper limit of the capacity factor is including the unavailability via e.g., maintenance
- see https://osemosys.readthedocs.io/en/latest/manual/Debugging%20a%20model.html#capacity-factors

## Contributor checklist

- [ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license / CC-BY-4.0 license (if a feature list).
- [ ] I have added myself to the list of contributors in `AUTHORS.md` if editing files outside feature lists of which I am a maintainer.
