### PR TITLE
Hotfix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 
 # These owners will be the owners for their respective feature lists.
 # BEGIN AUTO-GENERATED
-/tools/GenX/                   @sambuddhac @cfe316 @nspatank @lbonaldo @JesseJenkins @xuqingyu
+/tools/GenX/                   @virio-andreyana
 /tools/OSeMOSYS/               @willu47
 /tools/calliope/               @brynpickering
 /tools/pypsa/                  @euronion @SermishaNarayana

--- a/tools/GenX/.metadata.yml
+++ b/tools/GenX/.metadata.yml
@@ -13,7 +13,7 @@ description: GenX is a highly-configurable, open source electricity resource cap
     landscape
 docs: https://genxproject.github.io/GenX.jl/
 list_type: tool
-maintainers: sambuddhac, cfe316, nspatank, lbonaldo, JesseJenkins, xuqingyu
+maintainers: virio-andreyana
 name: GenX.jl
 shortname: GenX
 source: https://github.com/GenXProject/GenX.jl


### PR DESCRIPTION
Closes issue with incorrectly defined GenX feature list maintainers

## Contributor checklist

- [ ] Licensing information to new or modified files has been added (SPDX header, REUSE.toml, etc.).
- By contributing I agree to make my contributions available under the repository's MIT license / CC-BY-4.0 license (if a feature list).
- [ ] I have added myself to the list of contributors in `AUTHORS.md` if editing files outside feature lists of which I am a maintainer.
